### PR TITLE
[BDHK-200] Run E2E tests against newly deployed bundler always

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,3 +87,25 @@ jobs:
             docker-compose up -d
       - name: Get the outputs from Deploy image
         run: echo "The Command id is ${{ steps.deploy.outputs.command-id }}"
+
+  run-integration-tests:
+    name: Trigger E2Etests
+    needs: [deploy]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger E2Etests
+        run: |
+          response=$(curl -L -X POST -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{secrets.GH_ACTION_TRIGGER_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/blndgs/e2etests/actions/workflows/test-infra.yml/dispatches -d '{"ref":"main"}' \
+          -w "%{http_code}")
+
+          http_code=$(echo "$response" | tail -n1)
+
+          if [ "$http_code" -le 204 ]; then
+            echo "Workflow dispatch successful! (Status code: $http_code)"
+          else
+            echo "Workflow dispatch failed. (Status code: $http_code)"
+            exit 128;
+          fi


### PR DESCRIPTION
This PR triggers the workflow for the e2etests repo. Which always run against the bundler hence we will always run them against newly deployed versions