### PR TITLE
Explicity remove non whitelisted userops from the mempool

### DIFF
--- a/.github/workflows/ecs_deploy.yaml
+++ b/.github/workflows/ecs_deploy.yaml
@@ -31,6 +31,9 @@ jobs:
             echo "Not running on a pull request"
           fi
 
+      - name: Run Tests
+        run: make test
+
       - name: Determine Environment Prefix
         id: env_prefix
         run: |

--- a/srv/whitelist.go
+++ b/srv/whitelist.go
@@ -70,7 +70,7 @@ func CheckSenderWhitelist(db *badger.DB,
 				})
 				if err != nil {
 					logger.Error(err, "Sender not found in whitelist; removing transaction from batch", "address", userop.Sender.Hex())
-					ctx.Batch = append(ctx.Batch[:idx], ctx.Batch[idx+1:]...)
+					ctx.MarkOpIndexForRemoval(idx, "sender not whitelisted")
 				}
 			}
 

--- a/srv/whitelist_test.go
+++ b/srv/whitelist_test.go
@@ -68,7 +68,8 @@ func TestCheckSenderWhitelist(t *testing.T) {
 				whitelistedAddresses = append(whitelistedAddresses, common.HexToAddress(addr))
 			}
 
-			handler := CheckSenderWhitelist(db, whitelistedAddresses, logr.Discard())
+			handler, teardownFn := CheckSenderWhitelist(db, whitelistedAddresses, logr.Discard())
+			defer teardownFn()
 
 			batch := []*userop.UserOperation{}
 


### PR DESCRIPTION
This PR removes address from mempool to prevent it being added back again thus 
causing an infinite return to the pool