### PR TITLE
[BDHK-261] Always return errors from bundler handler execution to clients

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -110,8 +110,9 @@ func main() {
 	relayer := srv.New(values.SupportedEntryPoints[0], eoa, eth, chain, beneficiary, stdLogger)
 
 	stdLogger.Info("Using solver url", "url", values.SolverURL)
-	solver := solution.New(values.SolverURL, stdLogger)
-	if err := solution.ReportSolverHealth(values.SolverURL, stdLogger); err != nil {
+
+	solver := solution.New(values.SolverURL, stdLogger, relayer.GetOpHashes(), values.SupportedEntryPoints[0], chain)
+	if err := solver.ReportSolverHealth(values.SolverURL); err != nil {
 		log.Fatal(err)
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -122,7 +122,9 @@ func main() {
 
 	check := validator.ToStandaloneCheck()
 
-	whitelistHandler, whitelistCleanupFn := srv.CheckSenderWhitelist(db, values.WhiteListedAddresses, stdLogger)
+	whitelistHandler, whitelistCleanupFn := srv.CheckSenderWhitelist(db, values.WhiteListedAddresses,
+		stdLogger, relayer.GetOpHashes(),
+		values.SupportedEntryPoints[0], chain)
 
 	if whitelistHandler == nil {
 		stdLogger.Info("could not set up sender whitelist middleware")

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,8 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/holiman/uint256 v1.2.4 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zerologr v1.2.3
 	github.com/goccy/go-json v0.10.3
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/puzpuzpuz/xsync/v3 v3.1.0
@@ -67,7 +68,6 @@ require (
 	github.com/gorilla/websocket v1.5.1 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/holiman/uint256 v1.2.4 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,12 @@ github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1YCS1PXdKYWi8FsN0=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=
 github.com/hashicorp/go-bexpr v0.1.10/go.mod h1:oxlubA2vC/gFVfX1A6JGp7ls7uCDlfJn732ehYYg+g0=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -414,6 +414,10 @@ func waitForUserOpCompletion(ctx context.Context, ethClient *ethclient.Client,
 
 			span.SetAttributes(attribute.String("tx_hash", opHashes.Trx.String()))
 
+			if opHashes.Error != nil {
+				return nil, opHashes.Error
+			}
+
 			receipt, err := ethClient.TransactionReceipt(ctx, opHashes.Trx)
 			if err != nil {
 				if errors.Is(err, ethereum.NotFound) {

--- a/solution/validate.go
+++ b/solution/validate.go
@@ -3,13 +3,13 @@ package solution
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"unsafe"
 
 	multierror "github.com/hashicorp/go-multierror"
+	pkgerrors "github.com/pkg/errors"
 
 	"github.com/blndgs/bundler/srv"
 	"github.com/blndgs/bundler/utils"
@@ -91,10 +91,10 @@ func (ei *IntentsHandler) sendToSolverForValidation(
 				}
 
 				if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-					return fmt.Errorf("could not decode response from solver validation: %w", err)
+					return pkgerrors.Wrap(err, "could not decode response from solver validation")
 				}
 
-				err := errors.New(response.Error)
+				err := fmt.Errorf("solver validation failed: %s", response.Error)
 
 				// skip too much typecasting and just reuse the item from the batch
 				currentOpHash, unsolvedOpHash := utils.GetUserOpHash(batch[idx], ei.ep, ei.chainID)

--- a/solution/validate.go
+++ b/solution/validate.go
@@ -3,15 +3,20 @@ package solution
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"unsafe"
 
+	multierror "github.com/hashicorp/go-multierror"
+
+	"github.com/blndgs/bundler/srv"
 	"github.com/blndgs/bundler/utils"
 	"github.com/blndgs/model"
 	"github.com/goccy/go-json"
 	"github.com/stackup-wallet/stackup-bundler/pkg/modules"
+	"github.com/stackup-wallet/stackup-bundler/pkg/userop"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -35,13 +40,15 @@ func (ei *IntentsHandler) ValidateIntents() modules.BatchHandlerFunc {
 			return nil
 		}
 
-		return ei.sendToSolverForValidation(body)
+		return ei.sendToSolverForValidation(body, ctx.Batch)
 	}
 }
 
 // sendToSolverForValidation  sends the batch of UserOperations to the Solver.
 // to validate them
-func (ei *IntentsHandler) sendToSolverForValidation(body model.BodyOfUserOps) error {
+func (ei *IntentsHandler) sendToSolverForValidation(
+	body model.BodyOfUserOps,
+	batch []*userop.UserOperation) error {
 
 	parsedURL, err := url.Parse(ei.SolverURL)
 	if err != nil {
@@ -56,7 +63,7 @@ func (ei *IntentsHandler) sendToSolverForValidation(body model.BodyOfUserOps) er
 
 	var g errgroup.Group
 
-	for _, op := range body.UserOps {
+	for idx, op := range body.UserOps {
 		g.Go(func() error {
 			jsonBody, err := json.Marshal(op)
 			if err != nil {
@@ -78,10 +85,31 @@ func (ei *IntentsHandler) sendToSolverForValidation(body model.BodyOfUserOps) er
 			defer resp.Body.Close()
 
 			if resp.StatusCode != http.StatusOK {
-				return fmt.Errorf("solver returned non-OK status: %s", resp.Status)
+
+				var response struct {
+					Error string `json:"error"`
+				}
+
+				if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+					return fmt.Errorf("could not decode response from solver validation: %w", err)
+				}
+
+				err := errors.New(response.Error)
+
+				// skip too much typecasting and just reuse the item from the batch
+				currentOpHash, unsolvedOpHash := utils.GetUserOpHash(batch[idx], ei.ep, ei.chainID)
+
+				ei.txHashes.Compute(unsolvedOpHash, func(oldValue srv.OpHashes, loaded bool) (newValue srv.OpHashes, delete bool) {
+					return srv.OpHashes{
+						Error:  multierror.Append(oldValue.Error, err),
+						Solved: currentOpHash,
+					}, false
+				})
+
+				return err
 			}
 
-			return json.NewDecoder(resp.Body).Decode(&body)
+			return nil
 		})
 	}
 

--- a/utils/userop.go
+++ b/utils/userop.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"math/big"
+
+	"github.com/blndgs/model"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stackup-wallet/stackup-bundler/pkg/userop"
+)
+
+// GetUserOpHash returns the hash for the userop
+func GetUserOpHash(op *userop.UserOperation,
+	entrypointAddress common.Address,
+	chainID *big.Int) (currentOpHash string, unsolvedOpHash string) {
+
+	currentOpHash = op.GetUserOpHash(entrypointAddress, chainID).String()
+
+	unsolvedOpHash = currentOpHash
+	mOp := (model.UserOperation)(*op)
+	if mOp.HasIntent() && len(mOp.Signature) > model.KernelSignatureLength {
+		// Restore the userOp to unsolved state
+		mOp.CallData = mOp.Signature[mOp.GetSignatureEndIdx():]
+		mOp.Signature = mOp.GetSignatureValue()
+
+		unsolvedOpHash = mOp.GetUserOpHash(entrypointAddress, chainID).String()
+	}
+
+	return
+}
+


### PR DESCRIPTION
This makes sure to always surface the errors to the client such as failed validation when addresses are invalid
or user token balance is not enough to process the transaction on chain