### PR TITLE
Relax asset checks during simulation

### DIFF
--- a/srv/tenderly.go
+++ b/srv/tenderly.go
@@ -73,17 +73,7 @@ func SimulateTxWithTenderly(cfg *conf.Values,
 					return err
 				}
 
-				outgoingAssetChanges := resp.Result.AssetChanges[0]
-
-				if common.HexToAddress(outgoingAssetChanges.From).Hex() != userop.Sender.Hex() {
-					err = errors.New("first outward transaction does not belong to the userop sender")
-
-					logger.Error(err, "unexpected asset_changes structure")
-
-					computeHashFn(unsolvedOpHash, currentOpHash, err)
-					return err
-				}
-
+				// only check the last TX to make sure it is being deposited to the userop sender
 				incomingAssetChanges := resp.Result.AssetChanges[len(resp.Result.AssetChanges)-1]
 
 				if common.HexToAddress(incomingAssetChanges.To).Hex() != userop.Sender.Hex() {


### PR DESCRIPTION
In instance of `ETH` -> an ERC20 token, the first tx would be a `Mint` of `WETH`, that wouldn't accrue to the userop
sender.

This only checks the last leg of the asset changes accrues to the sender

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Simplified transaction validation logic to focus on the last transaction for improved performance.
	- Enhanced error handling and logging approach to streamline transaction flow assessment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->