### PR TITLE
Disable simulation by default

### DIFF
--- a/conf/values.go
+++ b/conf/values.go
@@ -114,7 +114,7 @@ func GetValues() *Values {
 	viper.SetDefault("erc4337_bundler_native_bundler_executor_tracer", ExecutorTracer)
 	viper.SetDefault("erc4337_bundler_status_timeout", time.Second*300)
 	viper.SetDefault("erc4337_bundler_address_whitelist", "")
-	viper.SetDefault("erc4337_bundler_tenderly_enable_simulation", true)
+	viper.SetDefault("erc4337_bundler_tenderly_enable_simulation", false)
 	viper.SetDefault("erc4337_bundler_simulation_timeout", defaultSimulationTimeout)
 
 	// Read in from .env file if available


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The default setting for the bundler's simulation feature has been changed to disabled, requiring users to enable it explicitly if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->