### PR TITLE
enable toggling simulation from GH action during deployment

### DIFF
--- a/.github/task-definition.json
+++ b/.github/task-definition.json
@@ -49,6 +49,10 @@
         {
           "name": "ERC4337_BUNDLER_SERVICE_NAME",
           "value": "VAR_ERC4337_BUNDLER_SERVICE_NAME"
+        },
+        {
+          "name": "ERC4337_BUNDLER_TENDERLY_ENABLE_SIMULATION",
+          "value": "VAR_ERC4337_BUNDLER_TENDERLY_ENABLE_SIMULATION"
         }
       ],
       "healthCheck": {

--- a/.github/workflows/ecs_deploy.yaml
+++ b/.github/workflows/ecs_deploy.yaml
@@ -106,6 +106,7 @@ jobs:
           VAR_ERC4337_BUNDLER_OTEL_COLLECTOR_URL: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
           VAR_ERC4337_BUNDLER_OTEL_COLLECTOR_HEADERS: ${{ secrets.OTEL_EXPORTER_OTLP_HEADERS }}
           VAR_ERC4337_ERC4337_BUNDLER_SERVICE_NAME: ${{ vars[format('{0}_BUNDLER_SERVICE_NAME', env.PREFIX)] }}
+          VAR_ERC4337_BUNDLER_TENDERLY_ENABLE_SIMULATION: ${{ vars[format('{0}_BUNDLER_TENDERLY_ENABLE_SIMULATION', env.PREFIX)] }}
         run: |
           cp -p .github/task-definition.json task-definition.json
           sed -i "s+AWS_REGION+${VAR_AWS_REGION}+g" task-definition.json
@@ -121,6 +122,7 @@ jobs:
           sed -i "s+VAR_ERC4337_BUNDLER_OTEL_COLLECTOR_URL+${VAR_ERC4337_BUNDLER_OTEL_COLLECTOR_URL}+g" task-definition.json
           sed -i "s+VAR_ERC4337_BUNDLER_OTEL_COLLECTOR_HEADERS+${VAR_ERC4337_BUNDLER_OTEL_COLLECTOR_HEADERS}+g" task-definition.json
           sed -i "s+VAR_ERC4337_ERC4337_BUNDLER_SERVICE_NAME+${VAR_ERC4337_ERC4337_BUNDLER_SERVICE_NAME}+g" task-definition.json
+          sed -i "s+VAR_ERC4337_BUNDLER_TENDERLY_ENABLE_SIMULATION+${VAR_ERC4337_BUNDLER_TENDERLY_ENABLE_SIMULATION}+g" task-definition.json
           cat task-definition.json
 
       - name: Deploy Amazon ECS task definition


### PR DESCRIPTION
This allows us configure if simulation can be toggled on GH actions deployment. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new environment variable for the service, enhancing configurability to toggle simulation features related to the ERC4337 bundler.
	- Enhanced deployment processes with the addition of an environment variable to support simulation capabilities in the Tenderly environment.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->