### PR TITLE
Return error to client if Bundler fails to get a solution

### DIFF
--- a/solution/solveintents.go
+++ b/solution/solveintents.go
@@ -25,10 +25,12 @@ import (
 	"unsafe"
 
 	"github.com/blndgs/bundler/srv"
+	"github.com/blndgs/bundler/utils"
 	"github.com/blndgs/model"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-logr/logr"
 	"github.com/goccy/go-json"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/puzpuzpuz/xsync/v3"
 
@@ -128,9 +130,24 @@ func (ei *IntentsHandler) SolveIntents() modules.BatchHandlerFunc {
 			return nil
 		}
 
+		computeHashFn := func(unsolvedOpHash, currentOpHash string, err error) {
+			ei.txHashes.Compute(unsolvedOpHash, func(oldValue srv.OpHashes, loaded bool) (newValue srv.OpHashes, delete bool) {
+				return srv.OpHashes{
+					Error:  multierror.Append(oldValue.Error, err),
+					Solved: currentOpHash,
+				}, false
+			})
+		}
+
 		if err := ei.sendToSolver(body); err != nil {
+
 			ei.logger.Error(err, "communication with solver failed")
-			return err
+
+			for _, op := range ctx.Batch {
+				currentOpHash, unsolvedOpHash := utils.GetUserOpHash(op, ei.ep, ei.chainID)
+				computeHashFn(unsolvedOpHash, currentOpHash, err)
+				return err
+			}
 		}
 
 		for idx, opExt := range body.UserOpsExt {
@@ -163,6 +180,9 @@ func (ei *IntentsHandler) SolveIntents() modules.BatchHandlerFunc {
 				err := errors.Errorf("unknown processing status: %s", opExt.ProcessingStatus)
 
 				ei.logger.Error(err, "unknown processing status")
+
+				currentOpHash, unsolvedOpHash := utils.GetUserOpHash(ctx.Batch[idx], ei.ep, ei.chainID)
+				computeHashFn(unsolvedOpHash, currentOpHash, err)
 				return err
 			}
 		}


### PR DESCRIPTION
compute error and display on clientside instead of waiting for the tx in the case of a solver failures.

we already know the tx will fail and infact will never go onchain if we fail to get a solution for the intents.

feels like an edge case but this is a very likely situation to happen. Intents sent to the bundler somehow not from us
( private mode ). Or the solver is down. 

While the transaction will eventually get dropped from the Mempool , it makes no sense to keep the client waiting for a response when there will be none 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error management for operations processing, allowing for more granular tracking of errors associated with individual operations.
	- Improved handling of unknown processing statuses to better manage and report errors.

- **Bug Fixes**
	- Resolved issues with error aggregation during batch operations, leading to improved clarity on operation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->