### PR TITLE
[BDHK-321] improve log metadata by adding service name and host name

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -90,6 +90,13 @@ func main() {
 
 	stdLogger := logger.NewZeroLogr(values.DebugMode)
 
+	h, err := os.Hostname()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	stdLogger = stdLogger.WithValues("service", values.ServiceName, "host", h)
+
 	validator := validations.New(
 		db,
 		rpcClient,


### PR DESCRIPTION
This helps us sift through logs and also allows us make more sense of the alerts we have sent up. Currently it is hard to know what service is failing and we have to look through error message to understand if solver or bundler

Also as we now have multiple deployments, it is useful to know the host - if it is a problematic one or something along those lines 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging functionality to include the hostname of the service, improving context for debugging and monitoring.
- **Bug Fixes**
	- Added error handling for hostname retrieval to ensure robust logging in case of failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->