### PR TITLE
Fix service name in logs

### DIFF
--- a/.github/task-definition.json
+++ b/.github/task-definition.json
@@ -48,7 +48,7 @@
         },
         {
           "name": "ERC4337_BUNDLER_SERVICE_NAME",
-          "value": "VAR_ERC4337_BUNDLER_SERVICE_NAME"
+          "value": "Bundler"
         },
         {
           "name": "ERC4337_BUNDLER_TENDERLY_ENABLE_SIMULATION",


### PR DESCRIPTION
![CleanShot 2024-09-09 at 20 52 47](https://github.com/user-attachments/assets/13f74352-349b-407d-8216-25c62d24685f)

> We already use `environment` to differentiate between dev, test and live so there's no issue with using the same service name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the bundler service name in the configuration for improved clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->