### PR TITLE
Fix consistency in communication with Solver

### DIFF
--- a/solution/solveintents.go
+++ b/solution/solveintents.go
@@ -237,12 +237,24 @@ func (h *IntentsHandler) ReportSolverHealth(solverURL string) error {
 
 // sendToSolver sends the batch of UserOperations to the Solver.
 func (ei *IntentsHandler) sendToSolver(body model.BodyOfUserOps) error {
+
+	parsedURL, err := url.Parse(ei.SolverURL)
+	if err != nil {
+		return err
+	}
+
+	parsedURL.Path = "/solve"
+	parsedURL.RawQuery = ""
+	parsedURL.Fragment = ""
+
+	solverURL := parsedURL.String()
+
 	jsonBody, err := json.Marshal(body)
 	if err != nil {
 		return err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, ei.SolverURL, bytes.NewBuffer(jsonBody))
+	req, err := http.NewRequest(http.MethodPost, solverURL, bytes.NewBuffer(jsonBody))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
In the past, we only had one endpoint to interact with the solver `/solve` but now it is at least 4, the
bundler still enforces having the solver url to include `/solve` in the path. This caused the tests to break yesterday
when we made the changes to deployment where the base url is now provided as it couldn't react the /solve endpoint.

> This is backwards compatible. If you add `/solve` in the env url it works. If you don't, it works too

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved URL handling for sending requests to the solver, ensuring consistent and correct endpoint usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->