### PR TITLE
use structured logger everywhere

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math/big"
@@ -45,8 +46,12 @@ func main() {
 	conf.SetLDFlags(CommitID, ModelVersion)
 	values := conf.GetValues()
 
+	stdLogger := logger.NewZeroLogr(values.DebugMode)
+
 	if strings.TrimSpace(values.ServiceName) == "" {
-		log.Fatal("please provide a valid service name")
+		err := errors.New("please provide a valid service name")
+		stdLogger.Error(err, "no service name provided")
+		os.Exit(1)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -62,46 +67,56 @@ func main() {
 
 	eoa, err := signer.New(values.PrivateKey)
 	if err != nil {
-		log.Fatal(err)
+		stdLogger.Error(err, "could not set up signer")
+		os.Exit(1)
 	}
+
 	beneficiary := common.HexToAddress(values.Beneficiary)
 
 	rpcClient, err := rpc.Dial(values.EthClientUrl)
 	if err != nil {
-		log.Fatalf("Failed to connect to Ethereum node: %v", err)
+		stdLogger.Error(err, "Failed to connect to Ethereum node")
+		os.Exit(1)
 	}
+
 	eth := ethclient.NewClient(rpcClient)
 
 	db, err := badger.Open(badger.DefaultOptions(values.DataDirectory))
 	if err != nil {
-		log.Fatal(err)
+		stdLogger.Error(err, "could not open badger database")
+		os.Exit(1)
 	}
+
 	defer db.Close()
 	runDBGarbageCollection(db)
 
 	mem, err := mempool.New(db)
 	if err != nil {
-		log.Fatal(err)
+		stdLogger.Error(err, "could not set up Mempool")
+		os.Exit(1)
 	}
 
 	chain, err := eth.ChainID(context.Background())
 	if err != nil {
-		log.Fatal(err)
+		stdLogger.Error(err, "could not fetch chain id from RPC")
+		os.Exit(1)
 	}
 
 	alt, err := altmempools.NewFromIPFS(chain, "", []string{})
 	if err != nil {
-		log.Fatal(err)
+		stdLogger.Error(err, "could not set up the alternative IPFS mempool")
+		os.Exit(1)
 	}
-
-	stdLogger := logger.NewZeroLogr(values.DebugMode)
 
 	h, err := os.Hostname()
 	if err != nil {
-		log.Fatal(err)
+		stdLogger.Error(err, "could not fetch host name of machine")
+		os.Exit(1)
 	}
 
-	stdLogger = stdLogger.WithValues("service", values.ServiceName, "host", h)
+	stdLogger = stdLogger.WithValues(
+		"service", values.ServiceName,
+		"host", h)
 
 	validator := validations.New(
 		db,
@@ -126,7 +141,8 @@ func main() {
 
 	solver := solution.New(values.SolverURL, stdLogger, relayer.GetOpHashes(), values.SupportedEntryPoints[0], chain)
 	if err := solver.ReportSolverHealth(values.SolverURL); err != nil {
-		log.Fatal(err)
+		stdLogger.Error(err, "could not verify Solver's healthcheck")
+		os.Exit(1)
 	}
 
 	erc4337Client := createERC4337Client(mem, values, chain, eth, rpcClient, stdLogger, rep, validator)
@@ -140,7 +156,8 @@ func main() {
 		values.SupportedEntryPoints[0], chain)
 
 	if whitelistHandler == nil {
-		stdLogger.Info("could not set up sender whitelist middleware")
+		err := "could not set up sender whitelist middleware"
+		stdLogger.Info(err, "whitelisting handler could not be setup")
 		os.Exit(1)
 	}
 
@@ -157,7 +174,8 @@ func main() {
 		check.Clean(),
 	)
 	if err := bundlerClient.Run(); err != nil {
-		log.Fatal(err)
+		stdLogger.Error(err, "could not run Bunclder client")
+		os.Exit(1)
 	}
 
 	var debugClient = client.NewDebug(eoa, eth, mem, rep, bundlerClient, chain, values.SupportedEntryPoints[0], beneficiary)
@@ -171,7 +189,8 @@ func main() {
 	go func() {
 		if err := handler.Run(fmt.Sprintf(":%d", values.Port)); err != nil {
 			cancel()
-			log.Fatal(err)
+			stdLogger.Error(err, "error while running HTTP Handler")
+			os.Exit(1)
 		}
 	}()
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -1,9 +1,9 @@
 package rpc
 
 import (
-	"log"
 	"math/big"
 	"net/http"
+	"os"
 
 	"github.com/blndgs/bundler/conf"
 	"github.com/blndgs/bundler/srv"
@@ -27,7 +27,8 @@ func NewRPCServer(values *conf.Values, logger logr.Logger, relayer *srv.Relayer,
 	r := gin.New()
 
 	if err := r.SetTrustedProxies(nil); err != nil {
-		log.Fatal(err)
+		logger.Error(err, "could not set up trusted proxies")
+		os.Exit(1)
 	}
 
 	var teardown = func() {}


### PR DESCRIPTION
non structured logs do not  get to Grafana. So we actually never saw this in the logs. We had to check Cloudwatch instead
directly

> Conversation at https://balloondogs.slack.com/archives/C069S2SLBQT/p1725983516569769?thread_ts=1725980690.778779&cid=C069S2SLBQT 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and logging mechanisms for improved clarity and context in error reporting.
  
- **Bug Fixes**
	- Improved robustness of error management, ensuring the application exits gracefully after logging errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->