### PR TITLE
Trigger tests only on main and testnet branches

### DIFF
--- a/.github/workflows/ecs_deploy.yaml
+++ b/.github/workflows/ecs_deploy.yaml
@@ -230,6 +230,7 @@ jobs:
     name: Trigger E2Etests
     needs: [deploy]
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/testnet'
     steps:
       - name: Determine Environment Prefix
         id: env_prefix
@@ -241,7 +242,6 @@ jobs:
           echo "PREFIX=$PREFIX"
 
       - name: Trigger E2Etests
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/testnet'
         run: |
           branch=$(echo ${{ env.PREFIX }} | awk '{print tolower($1)}')  
           response=$(curl -L -X POST -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/ecs_deploy.yaml
+++ b/.github/workflows/ecs_deploy.yaml
@@ -241,6 +241,7 @@ jobs:
           echo "PREFIX=$PREFIX"
 
       - name: Trigger E2Etests
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/testnet'
         run: |
           branch=$(echo ${{ env.PREFIX }} | awk '{print tolower($1)}')  
           response=$(curl -L -X POST -H "Accept: application/vnd.github+json" \

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -116,7 +116,9 @@ func main() {
 
 	stdLogger = stdLogger.WithValues(
 		"service", values.ServiceName,
-		"host", h)
+		"host", h,
+		"chain", getChainName(chain.Int64()),
+	)
 
 	validator := validations.New(
 		db,
@@ -260,4 +262,15 @@ func runDBGarbageCollection(db *badger.DB) {
 			}
 		}
 	}(db)
+}
+
+func getChainName(chainID int64) string {
+	switch chainID {
+	case 56:
+		return "BNB"
+	case 1:
+		return "ETH"
+	default:
+		return ""
+	}
 }


### PR DESCRIPTION
We don't have a `live` branch on the e2etests repo because production uses real money. No need to trigger the test there instead

I also added more context to the logs, this makes it easier for us to specifically seperate logs for multiple bundler instances. View only BSC logs, View only ETH logs and so forth

See https://github.com/blndgs/solver/actions/runs/10789277006/job/29929367356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated the deployment workflow to trigger end-to-end tests only on the `main` and `testnet` branches, improving test management and execution efficiency.
- **New Features**
	- Enhanced logging functionality to include chain information, providing more contextual details about the service's operational environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->