### PR TITLE
push docker image in separate task

### DIFF
--- a/.github/workflows/ecs_deploy.yaml
+++ b/.github/workflows/ecs_deploy.yaml
@@ -95,7 +95,7 @@ jobs:
   deploy:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/'))
     name: Deploy Image and Env Variables
-    needs: build
+    needs: build_docker_image
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ecs_deploy.yaml
+++ b/.github/workflows/ecs_deploy.yaml
@@ -48,17 +48,11 @@ jobs:
           TEST_RPC_URL: ${{ secrets[format('{0}_ERC4337_BUNDLER_ETH_CLIENT_URL', env.PREFIX)] }}
         run: make test-integration
 
-  deploy:
+  build_docker_image:
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/'))
-    name: Deploy Image and Env Variables
+    name: Build Docker Image and push to ECR
     needs: build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        network:
-          - eth
-          - bsc
-          - polygon
 
     steps:
       - uses: actions/checkout@v4
@@ -97,6 +91,41 @@ jobs:
           else
               echo "Image already exists on ECR, proceeding with deployment ..."
           fi
+
+  deploy:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/'))
+    name: Deploy Image and Env Variables
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        network:
+          - eth
+          - bsc
+          - polygon
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine Environment Prefix
+        id: env_prefix
+        run: |
+          BRANCH=${{ github.base_ref }}  # This is set for pull requests
+          [ -z "$BRANCH" ] && BRANCH=${{ github.ref_name }}  # Fallback to current branch if not a pull request
+          PREFIX=$(echo $BRANCH | awk -F'-' '{print toupper($1)}')  # Extract prefix and convert to upper case
+          echo "PREFIX=$PREFIX" >> $GITHUB_ENV
+          echo "PREFIX=$PREFIX"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets[format('{0}_AWS_ACCESS_KEY_ID', env.PREFIX)] }}
+          aws-secret-access-key: ${{ secrets[format('{0}_AWS_SECRET_ACCESS_KEY', env.PREFIX)] }}
+          aws-region: ${{ secrets[format('{0}_AWS_REGION', env.PREFIX)] }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
 
       - name: Change task definition for ${{ matrix.network }}
         id: change_task_definition


### PR DESCRIPTION
I have added a new build step called `build_docker_image`, this runs standalone apart from deployment. With the current
strategy added in #62 , each deployment step runs at the same time so they all correctly check that the docker image does not exists but by the time they each push the image, only one succeeds. can see failure https://github.com/blndgs/bundler/actions/runs/11455848630

This PR moves the image pushing to ECR as a separate step while the deployment of the bundler across multiple chains
happens in a separate build step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced deployment workflow for building and pushing Docker images to Amazon ECR.
	- Clear separation of image building and deployment processes.

- **Bug Fixes**
	- Ensured necessary environment configurations are consistently applied across jobs.

- **Refactor**
	- Renamed jobs for clarity and improved workflow control, ensuring proper execution order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->