### PR TITLE
Configuring deploy to wait for service stability

### DIFF
--- a/.github/workflows/ecs_deploy.yaml
+++ b/.github/workflows/ecs_deploy.yaml
@@ -171,7 +171,7 @@ jobs:
           cluster: ${{ secrets[format('{0}_ENV_NAME', env.PREFIX)] }}-backend
           service: ${{ secrets[format('{0}_ENV_NAME', env.PREFIX)] }}-bundler-${{ matrix.network }}
           task-definition: task-definition-${{ matrix.network }}.json
-          wait-for-service-stability: false
+          wait-for-service-stability: true
           wait-for-minutes: 5
 
   run-integration-tests:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an integration test trigger after deployment
- **Deployment Improvements**
	- Enhanced deployment process to wait for service stability
	- Implemented automated end-to-end testing workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->